### PR TITLE
Fix offset

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ pub struct Port {
     pub bits: Vec<BitVal>,
     /// Bit offset for mapping to HDL bit numbering
     #[serde(default)]
-    pub offset: usize,
+    pub offset: i64,
     /// Whether or not HDL bit numbering is MSB-first
     #[serde(default)]
     pub upto: usize,
@@ -227,7 +227,7 @@ pub struct Memory {
     pub size: usize,
     /// Lowest valid memory address
     #[serde(default)]
-    pub start_offset: usize,
+    pub start_offset: i64,
 }
 
 /// Represents the name of a net in a module
@@ -240,7 +240,7 @@ pub struct Netname {
     pub bits: Vec<BitVal>,
     /// Bit offset for mapping to HDL bit numbering
     #[serde(default)]
-    pub offset: usize,
+    pub offset: i64,
     /// Whether or not HDL bit numbering is MSB-first
     #[serde(default)]
     pub upto: usize,


### PR DESCRIPTION
I have some modules with a negative offset which fail to work, making this an i64 seems to fix it